### PR TITLE
rework processIn/processOut to only run at the correct times and bind the model context

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -126,9 +126,6 @@ function VeryModel(definition, args) {
                 if (meta.defs[field].hasOwnProperty('derive')) {
                     meta.data[field] = meta.defs[field].derive(this);
                 }
-                if (meta.defs[field].hasOwnProperty('processOut') && typeof meta.defs[field].processOut === 'function') {
-                    meta.data[field] = meta.defs[field].processOut(meta.data[field]);
-                }
                 return meta.data[field];
             }.bind(model));
 
@@ -173,11 +170,7 @@ function VeryModel(definition, args) {
                     throw new Error('Cannot set static values');
                 }
 
-                if (meta.defs[field].hasOwnProperty('processIn') && typeof meta.defs[field].processIn === 'function') {
-                    meta.data[field] = meta.defs[field].processIn(value);
-                } else {
-                    meta.data[field] = value;
-                }
+                meta.data[field] = value;
 
                 meta.isEmpty = false;
             });
@@ -191,13 +184,15 @@ function VeryModel(definition, args) {
 
         //load data en masse into the model
         //works recursively
-        model.loadData = function (value) {
+        model.loadData = function (value, process) {
             var meta = this.__verymeta;
+            var processIn;
 
             if (Array.isArray(meta.defs)) {
                 meta.data = [];
                 var valueoff = 0;
                 for (var vidx in meta.defs) {
+                    processIn = process && meta.defs[vidx].processIn && typeof meta.defs[vidx].processIn === 'function' ? meta.defs[vidx].processIn.bind(this) : false;
                     if (!meta.defs[vidx].required && value.length + valueoff < meta.defs.length) {
                         if (meta.defs[vidx].default === 'function') {
                             this[vidx] = meta.defs[vidx].default(this);
@@ -206,21 +201,34 @@ function VeryModel(definition, args) {
                         }
                         valueoff += 1;
                     } else {
-                        this[vidx] = value[vidx - valueoff];
+                        if (processIn) {
+                            this[vidx] = processIn(value[vidx - valueoff]).bind(this);
+                        } else {
+                            this[vidx] = value[vidx - valueoff];
+                        }
                     }
                 }
             } else {
                 Object.keys(value).forEach(function (key) {
                     if (!meta.defs.hasOwnProperty(key)) return;
+                    processIn = process && meta.defs[key].processIn && typeof meta.defs[key].processIn === 'function' ? meta.defs[key].processIn.bind(this) : false;
 
                     if (meta.defs[key].hasOwnProperty('collection')) {
                         for (var vidx in value[key]) {
                             meta.isEmpty = false;
-                            meta.data[key].push(value[key][vidx]);
+                            if (processIn) {
+                                meta.data[key].push(processIn(value[key][vidx]));
+                            } else {
+                                meta.data[key].push(value[key][vidx]);
+                            }
                         }
                     } else {
                         meta.isEmpty = false;
-                        model[key] = value[key];
+                        if (processIn) {
+                            model[key] = processIn(value[key]);
+                        } else {
+                            model[key] = value[key];
+                        }
                     }
                 }.bind(this));
             }
@@ -241,6 +249,7 @@ function VeryModel(definition, args) {
             }
 
             Object.keys(meta.defs).forEach(function (field) {
+                var processOut = meta.defs[field].processOut && typeof meta.defs[field].processOut === 'function' ? meta.defs[field].processOut.bind(this) : false;
                 var key = field;
                 if (meta.defs[field].private && !opts.withPrivate) {
                     return;
@@ -271,7 +280,7 @@ function VeryModel(definition, args) {
                     return;
                 }
 
-                obj[key] = this[field];
+                obj[key] = processOut ? processOut(this[field]) : this[field];
                 if (typeof obj[key] === 'undefined') {
                     delete obj[key];
                 }
@@ -379,7 +388,7 @@ function VeryModel(definition, args) {
 
         //if model.create passed in initial values, load them
         if (typeof value !== 'undefined') {
-            model.loadData(value);
+            model.loadData(value, true);
         }
 
         meta.creating = false;

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -49,10 +49,10 @@ module.exports = {
                 required: false,
                 type: VeryType().isDate(),
                 processIn: function (value) {
-                    return value.toISOString();
+                    return new Date(value);
                 },
                 processOut: function (value) {
-                    return new Date(value);
+                    return value.toISOString();
                 }
             }
         };
@@ -62,8 +62,8 @@ module.exports = {
             name: {title: 'Major-General', last: 'Stanley'},
             rank: 'Major-General',
             knowledge: [{name: 'animalculous', category: 'animal'}, {name: 'calculus', category: 'mathmatical'}],
-            birthday: new Date('1965-12-02T00:00:00.000Z')
-        });
+            birthday: '1965-12-02T00:00:00.000Z'
+        }, true);
         done();
     },
     tearDown: function (done) {
@@ -118,12 +118,9 @@ module.exports = {
         test.done();
     },
     'ProcessIn and processOut': function (test) {
-        test.ok(typeof model.__verymeta.data.birthday === 'string');
-        test.ok(model.__verymeta.data.birthday === '1965-12-02T00:00:00.000Z');
-        test.ok(typeof model.toObject().birthday === 'object');
-        test.ok(model.toObject().birthday.getUTCMonth() === 11); // months are 0 indexed
-        test.ok(model.toObject().birthday.getUTCDate() === 2);
-        test.ok(model.toObject().birthday.getUTCFullYear() === 1965);
+        test.ok(model.__verymeta.data.birthday instanceof Date);
+        test.ok(model.birthday instanceof Date);
+        test.ok(typeof model.toObject().birthday === 'string');
         test.done();
     },
     'Derived fields are populated': function (test) {


### PR DESCRIPTION
processIn is now only run during create, or if loadData is called with 'true' as the second parameter. processOut is only run during toObject. in addition, the "this" context is bound to the model instance in the processIn and processOut functions. also corrected tests to reflect these fixes.
