### PR TITLE
bind model instance context to derive functions

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -137,7 +137,7 @@ function VeryModel(definition, args) {
             model.__defineGetter__(field, function () {
                 var meta = this.__verymeta;
                 if (meta.defs[field].hasOwnProperty('derive')) {
-                    meta.data[field] = meta.defs[field].derive(this);
+                    meta.data[field] = meta.defs[field].derive.call(this, this);
                 }
                 return meta.data[field];
             }.bind(model));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "verymodel",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "homepage": "https://github.com/fritzy/VeryModel",
   "repository": {
     "type": "git",


### PR DESCRIPTION
the context is bound to the model instance everywhere else but here, so I fixed it for consistency's sake.
