### PR TITLE
Fix validator version to 2.1.x.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "description": "A full model system without the framework",
   "dependencies": {
-      "validator": "*",
+      "validator": "~2.1.0",
       "underscore": "*"
   },
   "devDependencies": {


### PR DESCRIPTION
VeryModel is incompatible with the just-released validator 3.0.0.
