### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ Noticed that the derived field, `name.full` was populated.
 
 <a name='field-def'></a>
 
-##Field Definitions
+## Field Definitions
 
 * [type](#def-type)
 * [model](#def-model)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
